### PR TITLE
Fix deploy workflow to handle invalid tree info error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,16 @@ jobs:
           cp public/CNAME dist/
           cp dist/index.html dist/404.html
 
+      - name: Handle invalid tree info error
+        run: |
+          git update-ref -d refs/heads/gh-pages
+          git fetch origin gh-pages
+          git checkout -b gh-pages origin/gh-pages
+          git rm -rf .
+          git clean -fdx
+          git commit --allow-empty -m "Initial commit"
+          git push origin gh-pages
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
Add a step to handle invalid tree info error in the deployment workflow.

* **Deployment Workflow**
  - Add a step to handle invalid tree info error by creating a new tree in `.github/workflows/deploy.yml`.
  - Ensure the workflow deploys the `client/dist` directory to GitHub Pages.
  - Ensure the workflow runs on the `main` branch.

