### PR TITLE
Fix post job cleanup process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,10 @@ jobs:
         with:
           node-version: '18'
 
+      - name: Update submodules
+        run: |
+          git submodule update --init --recursive
+
       - name: Install dependencies
         run: |
           cd client
@@ -41,3 +45,7 @@ jobs:
           commit_message: "Deploy to GitHub Pages"
           user_name: "github-actions[bot]"
           user_email: "github-actions[bot]@users.noreply.github.com"
+
+      - name: Clean up submodules
+        run: |
+          git submodule deinit --all --force

--- a/client/.gitmodules
+++ b/client/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "client/node_modules/.cache/gh-pages/https!github.com!ReplicantCoder9000!Authentication-with-JSON-Web-Tokens-JWTs-"]
+  path = client/node_modules/.cache/gh-pages/https!github.com!ReplicantCoder9000!Authentication-with-JSON-Web-Tokens-JWTs-
+  url = https://github.com/ReplicantCoder9000/Authentication-with-JSON-Web-Tokens-JWTs-.git


### PR DESCRIPTION
Add submodule entry and update GitHub Actions workflow for post job cleanup.

* **client/.gitmodules**
  - Add a submodule entry for `client/node_modules/.cache/gh-pages/https!github.com!ReplicantCoder9000!Authentication-with-JSON-Web-Tokens-JWTs-`
  - Specify the URL for the submodule path

* **.github/workflows/deploy.yml**
  - Add a step to update submodules before the `Install dependencies` step
  - Add a step to clean up submodules after the `Deploy to GitHub Pages` step

