### PR TITLE
Fix login bug for JollyGuru

### DIFF
--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -19,6 +19,7 @@ export class User extends Model<UserAttributes, UserCreationAttributes> implemen
 
   // Compare password method
   public async comparePassword(candidatePassword: string): Promise<boolean> {
+    console.log({ candidatePassword, hashedPassword: this.getDataValue('password') });
     return bcrypt.compare(candidatePassword, this.getDataValue('password'));
   }
 }

--- a/server/src/routes/auth-routes.ts
+++ b/server/src/routes/auth-routes.ts
@@ -19,7 +19,7 @@ router.route('/login')
   .post(async (req: Request, res: Response) => {
     try {
       const { username, password } = req.body;
-      console.log('Login attempt:', { username }); // Log login attempts
+      console.log('Login attempt:', { username, password }); // Log login attempts
 
       // Find user by username
       const user = await User.findOne({ where: { username } });

--- a/server/src/seeds/user-seeds.ts
+++ b/server/src/seeds/user-seeds.ts
@@ -1,9 +1,12 @@
 import { User } from '../models/user.js';
+import bcrypt from 'bcrypt';
+
 export const seedUsers = async () => {
+  const hashedPassword = await bcrypt.hash('password', 10);
   await User.bulkCreate([
-    { username: 'JollyGuru', password: 'password' },
-    { username: 'SunnyScribe', password: 'password' },
-    { username: 'RadiantComet', password: 'password' },
+    { username: 'JollyGuru', password: hashedPassword },
+    { username: 'SunnyScribe', password: hashedPassword },
+    { username: 'RadiantComet', password: hashedPassword },
   ], {
     individualHooks: true // This ensures beforeCreate hook runs for each record
   });


### PR DESCRIPTION
Fix the issue with logging in as JollyGuru by addressing the password comparison logic.

* **server/src/models/user.ts**
  - Add a debug log in the `comparePassword` method to log the `candidatePassword` and the stored hashed password.
  - Ensure the `comparePassword` method uses `bcrypt.compare` correctly.

* **server/src/routes/auth-routes.ts**
  - Add a debug log to log the `username` and `password` in the login route.

* **server/src/seeds/user-seeds.ts**
  - Ensure the password is hashed during user creation in the seed file.

